### PR TITLE
feat: enhance file opening behavior for newly added files and improve diff handling

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,7 +134,10 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       "gitCommits.previewFile",
       async (item: ChangeNode) => {
-        await vscode.commands.executeCommand("vscode.open", item.change.uri, {
+        // For newly added files, use the commit version (item.change.uri)
+        // For other files, also use the commit version for consistency
+        const uri = item.change.uri;
+        await vscode.commands.executeCommand("vscode.open", uri, {
           preview: true,
           viewColumn: vscode.ViewColumn.Active,
         });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,10 +134,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       "gitCommits.previewFile",
       async (item: ChangeNode) => {
-        // For newly added files, use the commit version (item.change.uri)
-        // For other files, also use the commit version for consistency
-        const uri = item.change.uri;
-        await vscode.commands.executeCommand("vscode.open", uri, {
+        await vscode.commands.executeCommand("vscode.open", item.change.uri, {
           preview: true,
           viewColumn: vscode.ViewColumn.Active,
         });

--- a/src/git-manager.ts
+++ b/src/git-manager.ts
@@ -1,4 +1,4 @@
-import { Repository as GitRepository, Commit as GitCommit, API, Change as GitChange, Remote } from './ext/git.d';
+import { Repository as GitRepository, Commit as GitCommit, API, Change as GitChange, Remote, Status } from './ext/git.d';
 import * as vscode from "vscode";
 import * as nodePath from 'path';
 import { promisify } from 'node:util';
@@ -130,6 +130,16 @@ export class GitManager {
   }
 
   async diffChange(change: Change): Promise<void> {
+    // For newly added files, just open the file instead of showing a diff
+    // because there's no parent version to compare against
+    if (change.status === Status.INDEX_ADDED) {
+      await vscode.commands.executeCommand("vscode.open", change.uri, {
+        preview: true,
+        viewColumn: vscode.ViewColumn.Active,
+      });
+      return;
+    }
+
     const leftSide = {
       uri: change.originalUri,
       label: change.commit.parentShortHash,


### PR DESCRIPTION
This PR fixes opening newly added files in commit history by opening the commit version directly and avoids attempting diffs against a non-existent parent.

Before:
<img width="743" height="427" alt="SCR-20251230-kfww" src="https://github.com/user-attachments/assets/2f473974-a1de-42ec-b3d4-c02b29a3ba0b" />

After:
<img width="842" height="581" alt="SCR-20251230-kgkj" src="https://github.com/user-attachments/assets/f75b417f-f80d-44e4-aa74-fa90dfe276d9" />
